### PR TITLE
Handle includer_ in CompileOptions copy/move constructors

### DIFF
--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -143,8 +143,11 @@ class CompileOptions {
   ~CompileOptions() { shaderc_compile_options_release(options_); }
   CompileOptions(const CompileOptions& other) {
     options_ = shaderc_compile_options_clone(other.options_);
+
+    // Clear the includer callbacks on the new object as it is not copyable.
+    shaderc_compile_options_set_include_callbacks(options_, nullptr, nullptr, nullptr);
   }
-  CompileOptions(CompileOptions&& other) {
+  CompileOptions(CompileOptions&& other) : includer_(std::move(other.includer_)) {
     options_ = other.options_;
     other.options_ = nullptr;
   }


### PR DESCRIPTION
Copying CompileOptions() results in a new object with possibly dangling pointers to the old include callbacks. This patch just clears them, since includer_ doesn't have a way to clone() it.

Moving CompileOptions() moves options_ but not includer_. This patch moves includer_ too.